### PR TITLE
Minor additions on the dashboard

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ if id -nG admin | grep -qw "sudo"; then
     systemctl stop pm2-pi.service
     systemctl disable pm2-pi.service
 
-    apt-get --assume-yes install nginx php-fpm php7.3-fpm lm-sensors
+    apt-get --assume-yes install nginx php-fpm php7.3-fpm
 
     mkdir /var/dashboard
     mkdir /etc/monitor-scripts

--- a/monitor-scripts/clean-memory.sh
+++ b/monitor-scripts/clean-memory.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sync; echo 3 > /proc/sys/vm/drop_caches; sync
+sync; dphys-swapfile swapoff; sync; dphys-swapfile swapon; sync

--- a/monitor-scripts/install-dashboard.sh
+++ b/monitor-scripts/install-dashboard.sh
@@ -2,5 +2,10 @@
 systemctl stop apache2.service
 systemctl disable apache2.service
 
+sleep 5
+
 systemctl start nginx
 systemctl enable nginx
+
+systemctl start php7.3-fpm.service
+systemctl enable php7.3-fpm.service

--- a/monitor-scripts/miner-update.sh
+++ b/monitor-scripts/miner-update.sh
@@ -31,10 +31,15 @@ if [[ $service == 'start' ]]; then
 
     currentdockerstatus=$(sudo docker ps -a -f name=miner --format "{{ .Status }}")
     if [[ $currentdockerstatus =~ 'Up' ]]; then
-      echo 'Removing old docker firmware image to save space ...'
+      echo 'Removing old docker firmware image to save space ...' >> /var/dashboard/logs/miner-update.log
       docker rmi $(docker images -q quay.io/team-helium/miner:$currentversion)
       echo 'stopped' > /var/dashboard/services/miner-update
       echo $version > /var/dashboard/statuses/current_miner_version
+      echo "DISTRIB_RELEASE=$(echo $version | sed -e 's/miner-arm64_//')" > /etc/lsb_release
+      echo 'Restarting Bluetooth Config Appplication ...' >> /var/dashboard/logs/miner-update.log
+      sudo /home/pi/config/_build/prod/rel/gateway_config/bin/gateway_config stop
+      sleep 2
+      sudo /home/pi/api/tool/startAdvertise.sh
       echo 'Update complete.' >> /var/dashboard/logs/miner-update.log
     else
       echo 'stopped' > /var/dashboard/services/miner-update

--- a/monitor-scripts/miner-update.sh
+++ b/monitor-scripts/miner-update.sh
@@ -27,10 +27,12 @@ if [[ $service == 'start' ]]; then
       docker rm miner
       echo 'Acquiring and starting latest docker version...' >> /var/dashboard/logs/miner-update.log
       docker image pull quay.io/team-helium/miner:$version >> /var/dashboard/logs/miner-update.log
-      docker run -d --init --ulimit nofile=64000:64000 --env REGION_OVERRIDE=EU868 --restart always --publish 1680:1680/udp --publish 44158:44158/tcp --name miner --mount type=bind,source=/home/pi/hnt/miner,target=/var/data --device /dev/i2c-0 --net host --privileged -v /var/run/dbus:/var/run/dbus --mount type=bind,source=/home/pi/hnt/miner/configs/sys.config,target=/config/sys.config quay.io/team-helium/miner:$version >> /var/dashboard/logs/miner-update.log
+      docker run -d --init --ulimit nofile=64000:64000 --env REGION_OVERRIDE=EU868 --restart always --publish 1680:1680/udp --publish 44158:44158/tcp --name miner --mount type=bind,source=/home/pi/hnt/miner,target=/var/data --mount type=bind,source=/home/pi/hnt/miner/log,target=/var/log/miner --device /dev/i2c-0 --net host --privileged -v /var/run/dbus:/var/run/dbus --mount type=bind,source=/home/pi/hnt/miner/configs/sys.config,target=/config/sys.config quay.io/team-helium/miner:$version >> /var/dashboard/logs/miner-update.log
 
     currentdockerstatus=$(sudo docker ps -a -f name=miner --format "{{ .Status }}")
     if [[ $currentdockerstatus =~ 'Up' ]]; then
+      echo 'Removing old docker firmware image to save space ...'
+      docker rmi $(docker images -q quay.io/team-helium/miner:$currentversion)
       echo 'stopped' > /var/dashboard/services/miner-update
       echo $version > /var/dashboard/statuses/current_miner_version
       echo 'Update complete.' >> /var/dashboard/logs/miner-update.log

--- a/monitor-scripts/temp.sh
+++ b/monitor-scripts/temp.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-data=$(sensors cpu_thermal-virtual-0 | grep temp1)
+data=$(vcgencmd measure_temp)
 
-if [[ $data =~ temp1:(.*) ]]; then
+if [[ $data =~ temp=(.*) ]]; then
   match="${BASH_REMATCH[1]}"
 fi
 

--- a/systemd/clean-memory.service
+++ b/systemd/clean-memory.service
@@ -1,0 +1,5 @@
+[Unit]
+Description=Memory cleanup 
+
+[Service]
+ExecStart=/etc/monitor-scripts/clean-memory.sh

--- a/systemd/clean-memory.timer
+++ b/systemd/clean-memory.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run the clean memory job every hour.
+
+[Timer]
+OnBootSec=1h
+OnUnitActiveSec=1h
+AccuracySec=1m
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Hi, as I said to you in discord, this are the changes that I did on the dashboard files:
- added clean memory script to clean buffers/cache and swap every hour;
- removed lm-sensors dependency for temp, used vcgencmd measure_temp, which is built in;
- mounted miner logs to /home/pi/hnt/miner/log which permits the dashboard to have access to it without issueing docker commands;
- added the removal of the older docker images when upgrading with success the version;
- added the /etc/lsb_release update when there is a new firmware version. This file is responsible to show the firmware version on helium app.