### PR TITLE
Replace nebra endpoints with sensecap

### DIFF
--- a/monitor-scripts/auto-maintain.sh
+++ b/monitor-scripts/auto-maintain.sh
@@ -12,7 +12,7 @@ if [[ $service == 'enabled' ]]; then
   current_docker_status=$(sudo docker ps -a -f name=miner --format "{{ .Status }}")
   current_info_height=$(cat /var/dashboard/statuses/infoheight)
   live_height=$(cat /var/dashboard/statuses/current_blockheight)
-  snap_height=$(wget -q https://helium-snapshots.nebra.com/latest.json -O - | grep -Po '\"height\": [0-9]*' | sed 's/\"height\": //')
+  snap_height=$(curl --silent https://snapshots-wtf.sensecapmx.cloud/latest-snap.json|awk -F':' '{print $3}'| rev | cut -c2- | rev)
   pubkey=$(cat /var/dashboard/statuses/animal_name)
   echo "Miner Version: $miner_version"
   echo "Latest Miner Version: $latest_miner_version"
@@ -57,7 +57,7 @@ if [[ $service == 'enabled' ]]; then
 
   if [[ $blockheight_difference -ge 500 ]]; then
     echo "[$(date)] Big difference in blockheight, doing a fast sync..." >> /var/dashboard/logs/auto-maintain.log
-    wget https://helium-snapshots.nebra.com/snap-$snap_height -O /home/pi/hnt/miner/snap/snap-latest
+    wget https://snapshots-wtf.sensecapmx.cloud/snap-$snap_height -O /home/pi/hnt/miner/snap/snap-$snap_height
     docker exec miner miner repair sync_pause
     docker exec miner miner repair sync_cancel
     docker exec miner miner snapshot load /var/data/snap/snap-latest

--- a/monitor-scripts/fastsync.sh
+++ b/monitor-scripts/fastsync.sh
@@ -3,8 +3,8 @@ service=$(cat /var/dashboard/services/fastsync | tr -d '\n')
 
 if [[ $service == 'start' ]]; then
   echo 'running' > /var/dashboard/services/fastsync
-  snap_height=$(wget -q https://helium-snapshots.nebra.com/latest.json -O - | grep -Po '\"height\": [0-9]*' | sed 's/\"height\": //')
-  wget https://helium-snapshots.nebra.com/snap-$snap_height -O /home/pi/hnt/miner/snap/snap-latest
+  snap_height=$(curl --silent https://snapshots-wtf.sensecapmx.cloud/latest-snap.json|awk -F':' '{print $3}'| rev | cut -c2- | rev)
+  wget https://snapshots-wtf.sensecapmx.cloud/snap-$snap_height -O /home/pi/hnt/miner/snap/snap-$snap_height
   docker exec miner miner repair sync_pause
   docker exec miner miner repair sync_cancel
   docker exec miner miner snapshot load /var/data/snap/snap-latest


### PR DESCRIPTION
Thanks to @herrtakacs for finding this, and for providing a fix.

The snapshots in the `nebra` endpoints are updated too seldom, which can cause the miner to load an old snapshot (1000 blocks behind blockchain), so these should be replaced with the ones in the `sensecap` endpoints, which are updated every 30 minutes.