### PR TITLE
Confirm prompt for reboot

### DIFF
--- a/dashboard/public/js/functions.js
+++ b/dashboard/public/js/functions.js
@@ -23,6 +23,10 @@ function EnableService(ServiceName)
 
 function RebootDevice()
 {
+	if (!window.confirm("Are you sure that you want to reboot the miner now?")) {
+		return;
+	}
+	
 	httpRequest = new XMLHttpRequest();
 	httpRequest.open('GET', 'RebootDevice.php', true);
 	httpRequest.send();


### PR DESCRIPTION
Currently, when clicking the reboot button by accident the miner reboots immediately. In other areas of the dashboard, a separate confirmation is required. To not accidentally reboot the miner, when there is no reason for it, a prompt was added, so the user has to confirm the reboot.