### PR TITLE
Issue #30 password reset fix

### DIFF
--- a/dashboard/public/ResetPassword.php
+++ b/dashboard/public/ResetPassword.php
@@ -3,8 +3,8 @@ $current_users_tmp = explode("\n", file_get_contents("/var/dashboard/.htpasswd")
 $current_users = [];
 $x = 0;
 
-$clearTextPassword = trim(htmlentities(strip_tags($_POST['password'])));
-$confirmPassword = trim(htmlentities(strip_tags($_POST['confirmpassword'])));
+$clearTextPassword = trim(substr($_POST['password'],0,128));
+$confirmPassword = trim(substr($_POST['confirmpassword'],0,128));
 
 if(($clearTextPassword == $confirmPassword) && $clearTextPassword != "")
 {

--- a/dashboard/public/js/functions.js
+++ b/dashboard/public/js/functions.js
@@ -34,7 +34,7 @@ function ResetPasswordPrompt()
 {
 	var passwordbox = document.createElement("div");
 	passwordbox.className = "closeable_prompt_overlay";
-	passwordbox.innerHTML = '<div id="closeable_prompt"><div id="prompt_title"><h2>Reset Password</h2><button type="button" onclick="ClosePrompt()" value="Close" title="Close" id="CloseButton">X</button></div><div id="prompt_body"><div id="inputs"><label for="password">Password:</label><input type="password" id="password" name="password"><br /><label for="confirm_password">Confirm Password:</label><input type="password" name="confirm_password" id="confirm_password" /></div></div><div id="prompt_footer"><button id="reset_password_button" onclick="ResetPassword()"; type="button">Submit</button></div></div>';
+	passwordbox.innerHTML = '<div id="closeable_prompt"><div id="prompt_title"><h2>Reset Password</h2><button type="button" onclick="ClosePrompt()" value="Close" title="Close" id="CloseButton">X</button></div><div id="prompt_body"><div id="inputs"><label for="password">Password:</label><input type="password" id="password" name="password" maxlength="128"><br /><label for="confirm_password">Confirm Password:</label><input type="password" name="confirm_password" id="confirm_password" maxlength="128" /></div></div><div id="prompt_footer"><button id="reset_password_button" onclick="ResetPassword()"; type="button">Submit</button></div></div>';
 	var body = document.body.appendChild(passwordbox);
 }
 
@@ -42,7 +42,7 @@ function ResetPassword()
 {
 	var password = document.getElementById("password").value;
 	var confirmpassword = document.getElementById("confirm_password").value;
-	var params = 'password='+password+'&confirmpassword='+confirmpassword;
+	var params = 'password='+encodeURIComponent(password)+'&confirmpassword='+encodeURIComponent(confirmpassword);
 	httpRequest = new XMLHttpRequest();
 	httpRequest.open('POST', 'ResetPassword.php', true);
 	httpRequest.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');


### PR DESCRIPTION
Added encodeURIComponent() call to building of reset parameters ResetPassword() in functions.js
Added maxlength=128 for password fields in ResetPasswordPrompt() for sanity check
Removed htmlentities() and striptags() calls on password fields in ResetPassword.php as changes the value of the password and they're not echo'd to browser.
added substr(xxx,0,128) to limit length of passwords to 128 for sanity
